### PR TITLE
Fixed composer.json, otherwise it won't install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
 			"role": "Lead Developer"
 		}
 	],
+	"require": {
+		"php": ">=5.3.3"
+	},
 	"extra": {
 		"display-name": "External Links Open in New Window",
 		"soft-require": {


### PR DESCRIPTION
In a plain PHPBB 3.1.10 extensions won't install without the required php parameter.